### PR TITLE
Adding Security and IANA considerations section

### DIFF
--- a/draft-schwenkschuster-oauth-spiffe-client-auth.md
+++ b/draft-schwenkschuster-oauth-spiffe-client-auth.md
@@ -424,7 +424,7 @@ The narrow scope of applicability does not make it a viable alternative to the S
 
 Client authentication using JWT-SVIDs has the same security considerations as described in {{RFC6749}} and {{RFC7521}}.
 
-Client authentication using X509-SVIDs has the same security considerations as described in {{RFC8705}}. The validation rules in section 3.2 protect against an OAuth2 token being issued (or being issued incorrectly) to a client that did not present an appropriate X509-SVID. 
+Client authentication using X509-SVIDs has the same security considerations as described in {{RFC8705}}. The validation rules in section 3.2 protect against an OAuth2 token being issued (or being issued incorrectly) to a client that did not present an appropriate X509-SVID.
 
 The issues described in Section 5.2 above include the threat that an authorization server may have the incorrect
 trust stores configured to validate the client SVID. This could result in an incorrectly issued token to an attacker if the attacker is able to obtain a certificate that can be validated by one of the misconfigured trust anchors in the trust store.


### PR DESCRIPTION
This PR includes a security considerations section that largely references the security considerations from the RFCs that this references, a there are no significant differences.

The IANA considerations list the new URN requested for using SPIFFE. It follows the format described in RFC 6755. 

Also some typos are fixed in other sections.